### PR TITLE
fix: Respecting line breaks of line breaks

### DIFF
--- a/src/components/editor.tsx
+++ b/src/components/editor.tsx
@@ -119,16 +119,32 @@ export function CodeEditor(props: CodeEditorProps) {
 
               case 'STDOUT': {
                 const { msg } = line;
-                return <code key={i}>{msg}</code>;
+                if (msg === '') {
+                  return (
+                    <code key={i}>
+                      <br />
+                    </code>
+                  );
+                } else {
+                  return <code key={i}>{msg}</code>;
+                }
               }
 
               case 'STDERR': {
                 const { msg } = line;
-                return (
-                  <code className="text-red-700" key={i}>
-                    {msg}
-                  </code>
-                );
+                if (msg === '') {
+                  return (
+                    <code key={i}>
+                      <br />
+                    </code>
+                  );
+                } else {
+                  return (
+                    <code className="text-red-700" key={i}>
+                      {msg}
+                    </code>
+                  );
+                }
               }
             }
           })}


### PR DESCRIPTION
```
print("\n\n\n\n")
```

Resulted in:

```
<code></code>
<code></code>
<code></code>
<code></code>
```

Fixed, so now it'll insert breaks appropriately:

```
<code><br /></code>
<code><br /></code>
<code><br /></code>
<code><br /></code>
```